### PR TITLE
allow negative indices in edict

### DIFF
--- a/dnutils/tools.py
+++ b/dnutils/tools.py
@@ -95,7 +95,7 @@ def last(it, transform=None):
     return idxif(it, -1, transform=transform)
 
 
-sqbrpattern = re.compile(r'\[(\d+)\]')
+sqbrpattern = re.compile(r'\[(-?\d+)\]')
 
 
 class edict(dict):


### PR DESCRIPTION
the sqbrpattern only allows positive indices in the xpath. You might want to refer to the last (n) objects in a list, e.g. 'key1/key2/[-1]/key3'.